### PR TITLE
Keep baseurl blank

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-baseurl: "/2020"
+baseurl: ""


### PR DESCRIPTION
The baseurl makes it difficult to see previews. In prod the sub url is set in the server