### PR TITLE
Prevent genuine assets from being blocked by adblockers

### DIFF
--- a/_includes/supporter.html
+++ b/_includes/supporter.html
@@ -1,4 +1,4 @@
-<div id="sponsor" class="page-wrapper sponsor-section">
+<div id="supporter" class="page-wrapper supporter-section">
   <div class="page-details">
     <div class="title">Sponsors</div>
     <div class="description">
@@ -11,16 +11,16 @@
     </div>
     {% assign levels = site.data.sponsors | map: 'level' | uniq %}
     {% if levels %}
-    <div class="sponsor-section levels">
+    <div class="supporter-section levels">
       {% for level in levels %}
       <div class="level">
         <div class="level-heading">{{ level | capitalize }}</div>
         <div class="level-list">
           {% assign sponsors = site.data.sponsors | where: 'level', level %}
           {% for sponsor in sponsors %}
-          <div class="sponsor">
-            <div class="sponsor-logo">
-              <img class="sponsor-logo-image" src="{{ sponsor.logo | relative_url }}" alt="{{ sponsor.name }}" width="200" height="200"/>
+          <div class="supporter">
+            <div class="supporter-logo">
+              <img class="supporter-logo-image" src="{{ sponsor.logo | relative_url }}" alt="{{ sponsor.name }}" width="200" height="200"/>
             </div>
             <div class="hover-container">
             <div class="hover-container-content">

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -474,10 +474,10 @@ body {
     }
   }
 
-  // Sponsor section styles
-  .sponsor-section {
+  // supporter section styles
+  .supporter-section {
     position: relative;
-    .sponsor{
+    .supporter{
       margin-top: 1rem;
     }
     .level-heading {
@@ -498,7 +498,7 @@ body {
       flex-direction: row;
       flex-wrap: wrap;
 
-      .sponsor-logo {
+      .supporter-logo {
         cursor: pointer;
         img {
           margin-top: 1rem;

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -29,7 +29,7 @@ document.querySelectorAll(".date").forEach(function(element) {
 })
 
 
-let sponsorLogos = document.getElementsByClassName('sponsor-logo-image')
+let sponsorLogos = document.getElementsByClassName('supporter-logo-image')
 
 for(let domElem of sponsorLogos){
       let hoverContentContainer = domElem.parentNode.parentNode.querySelector('.hover-container-content')
@@ -56,5 +56,5 @@ for(let domElem of hoverContainerContentCloseBtns){
     console.log(event)
     event.target.parentNode.parentNode.style.display = 'none'
   })
-   
+
 }


### PR DESCRIPTION
The myriad of adblockers around the world do something called
Cosmetic Filtering which basically resize DOM elements to 0 width
0 height so that they are not visible to the user.

Using a class `sponsor-logo` on the container for the sponsor logo
made them prone to being hidden by adblockers.

This PR practically renames all occurrences of `sponsor` in the
rendered HTML DOM.

A log snippet from my uBlock Origin extension:

![2020-09-18-232449_1905x763_scrot](https://user-images.githubusercontent.com/10010419/93631266-e496ec80-fa08-11ea-9025-7c8b36633b66.png)
